### PR TITLE
chore(ci): migrate github actions to pnpm and optimize artifact uploads

### DIFF
--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -12,19 +12,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js with pnpm
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: Enable Corepack + Install pnpm
-        run: corepack enable && corepack prepare pnpm@latest --activate
+      - name: Enable Corepack and install pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck
+      - name: Type-check (optional)
         run: pnpm compile
 
       - name: Build and Package Extensions
@@ -34,20 +36,20 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension-zip
-          path: .output/*-chrome.zip
+          path: .output/*.chrome.zip
 
       - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: firefox-extension-zip
-          path: .output/*-firefox.zip
+          path: .output/*.firefox.zip
 
   report:
     needs: [build-zips]
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Report
+      - name: Report failure
         run: |
-          echo "Something went wrong"
+          echo "❌ Build or packaging failed."
           echo "${{ toJSON(github) }}"

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -7,15 +7,13 @@ on:
 jobs:
   build-zips:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Enable Corepack
-        run: |
-          set -e
-          corepack enable
-        shell: bash
+        run: corepack enable
 
       - name: Setup Node.js with pnpm cache
         uses: actions/setup-node@v4
@@ -23,63 +21,78 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: Install dependencies
+      - name: Extract package name and version
+        id: extract_pkg
         run: |
-          set -e
-          pnpm install --frozen-lockfile
-        shell: bash
+          node -e "
+            const fs = require('fs');
+            try {
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+              if (!pkg.name || !pkg.version) {
+                console.error('package.json missing name or version');
+                process.exit(1);
+              }
+              console.log(`::set-output name=name::${pkg.name}`);
+              console.log(`::set-output name=version::${pkg.version}`);
+            } catch (err) {
+              console.error('Error reading package.json:', err);
+              process.exit(1);
+            }
+          "
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build and Package Extensions
-        run: |
-          set -e
-          pnpm zip:all
-        shell: bash
+        run: pnpm zip:all
 
-      - name: Extract name and version from package.json
-        id: extract_pkg
-        shell: node
-        run: |
-          const fs = require('fs');
-          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-          if (!pkg.name || !pkg.version) {
-            console.error('package.json missing name or version');
-            process.exit(1);
-          }
-          console.log(`::set-output name=name::${pkg.name}`);
-          console.log(`::set-output name=version::${pkg.version}`);
-
-      - name: Debug - List output directory and subfolders
+      - name: Debug - List output directory
         run: |
           echo "=== Contents of .output directory ==="
-          ls -la .output || (echo ".output directory not found" && exit 1)
-          echo "=== Contents of chrome-mv3 directory ==="
-          ls -la .output/chrome-mv3 || (echo "chrome-mv3 directory not found" && exit 1)
-          echo "=== Contents of firefox-mv2 directory ==="
-          ls -la .output/firefox-mv2 || (echo "firefox-mv2 directory not found" && exit 1)
-        shell: bash
+          ls -la .output/ || echo "No .output directory found"
+          echo "=== All zip files in project ==="
+          find . -name "*.zip" -type f || echo "No zip files found"
 
-      - name: Prepare artifacts directory with dynamic names
+      - name: Debug - List chrome-mv3 and firefox-mv2 directories
+        run: |
+          echo "=== Contents of .output/chrome-mv3 ==="
+          ls -la .output/chrome-mv3 || echo "No chrome-mv3 directory found"
+          echo "=== Contents of .output/firefox-mv2 ==="
+          ls -la .output/firefox-mv2 || echo "No firefox-mv2 directory found"
+
+      - name: Prepare artifacts directory and copy build outputs
         run: |
           set -e
-          ARTIFACT_BASE="${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}"
-          mkdir -p artifacts
-          cp -r .output/chrome-mv3 "artifacts/${ARTIFACT_BASE}-chrome-mv3"
-          cp -r .output/firefox-mv2 "artifacts/${ARTIFACT_BASE}-firefox-mv2"
-          echo "Artifacts prepared:"
-          ls -la artifacts
-        shell: bash
+          mkdir -p artifacts/chrome-mv3 artifacts/firefox-mv2
+          if [ -d ".output/chrome-mv3" ]; then
+            cp -r .output/chrome-mv3/* artifacts/chrome-mv3/
+          else
+            echo "Warning: .output/chrome-mv3 directory not found"
+          fi
+          if [ -d ".output/firefox-mv2" ]; then
+            cp -r .output/firefox-mv2/* artifacts/firefox-mv2/
+          else
+            echo "Warning: .output/firefox-mv2 directory not found"
+          fi
 
-      - name: Upload chrome-mv3 artifact
+      - name: Debug - List artifacts directory after copy
+        run: |
+          echo "=== Contents of artifacts/chrome-mv3 ==="
+          ls -la artifacts/chrome-mv3 || echo "No chrome-mv3 artifacts found"
+          echo "=== Contents of artifacts/firefox-mv2 ==="
+          ls -la artifacts/firefox-mv2 || echo "No firefox-mv2 artifacts found"
+
+      - name: Upload Chrome extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3
-          path: artifacts/${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3
+          path: artifacts/chrome-mv3/*
 
-      - name: Upload firefox-mv2 artifact
+      - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2
-          path: artifacts/${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2
+          path: artifacts/firefox-mv2/*
 
   report:
     needs: build-zips
@@ -89,11 +102,6 @@ jobs:
       - name: Report failure
         run: |
           echo "❌ Build or packaging failed."
-          echo "GITHUB_RUN_ID=${{ github.run_id }}"
-          echo "GITHUB_WORKFLOW=${{ github.workflow }}"
-          echo "GITHUB_JOB=${{ github.job }}"
-          echo "GITHUB_REF=${{ github.ref }}"
-          echo "GITHUB_SHA=${{ github.sha }}"
-          echo "GITHUB_EVENT_NAME=${{ github.event_name }}"
-          echo "Full github context:"
-          echo "${{ toJSON(github) }}"
+          echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -24,8 +24,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Type-check (optional)
+        run: pnpm compile
+
       - name: Build and Package Extensions
         run: pnpm zip:all
+
+      - name: Debug - List output directory
+        run: |
+          echo "=== Contents of .output directory ==="
+          ls -la .output/ || echo "No .output directory found"
+          echo "=== All zip files in project ==="
+          find . -name "*.zip" -type f || echo "No zip files found"
 
       - name: Upload Chrome extension artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -21,25 +21,6 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: Extract package name and version
-        id: extract_pkg
-        run: |
-          node -e "
-            const fs = require('fs');
-            try {
-              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-              if (!pkg.name || !pkg.version) {
-                console.error('package.json missing name or version');
-                process.exit(1);
-              }
-              console.log(`::set-output name=name::${pkg.name}`);
-              console.log(`::set-output name=version::${pkg.version}`);
-            } catch (err) {
-              console.error('Error reading package.json:', err);
-              process.exit(1);
-            }
-          "
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -53,34 +34,30 @@ jobs:
           echo "=== All zip files in project ==="
           find . -name "*.zip" -type f || echo "No zip files found"
 
-      - name: Debug - List chrome-mv3 and firefox-mv2 directories
+      - name: Copy chrome-mv3 and firefox-mv2 to artifacts directory
         run: |
-          echo "=== Contents of .output/chrome-mv3 ==="
-          ls -la .output/chrome-mv3 || echo "No chrome-mv3 directory found"
-          echo "=== Contents of .output/firefox-mv2 ==="
-          ls -la .output/firefox-mv2 || echo "No firefox-mv2 directory found"
-
-      - name: Prepare artifacts directory and copy build outputs
-        run: |
-          set -e
           mkdir -p artifacts/chrome-mv3 artifacts/firefox-mv2
-          if [ -d ".output/chrome-mv3" ]; then
-            cp -r .output/chrome-mv3/* artifacts/chrome-mv3/
-          else
-            echo "Warning: .output/chrome-mv3 directory not found"
-          fi
-          if [ -d ".output/firefox-mv2" ]; then
-            cp -r .output/firefox-mv2/* artifacts/firefox-mv2/
-          else
-            echo "Warning: .output/firefox-mv2 directory not found"
-          fi
+          cp -r .output/chrome-mv3/* artifacts/chrome-mv3/ || echo "Warning: .output/chrome-mv3 missing or empty"
+          cp -r .output/firefox-mv2/* artifacts/firefox-mv2/ || echo "Warning: .output/firefox-mv2 missing or empty"
 
-      - name: Debug - List artifacts directory after copy
+      - name: Extract name and version from package.json
+        id: extract_pkg
+        shell: node
         run: |
-          echo "=== Contents of artifacts/chrome-mv3 ==="
-          ls -la artifacts/chrome-mv3 || echo "No chrome-mv3 artifacts found"
-          echo "=== Contents of artifacts/firefox-mv2 ==="
-          ls -la artifacts/firefox-mv2 || echo "No firefox-mv2 artifacts found"
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+          if (!pkg.name || !pkg.version) {
+            console.error('package.json missing name or version');
+            process.exit(1);
+          }
+          const name = pkg.name.trim();
+          const version = pkg.version.trim();
+          require('fs').appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\nversion=${version}\n`);
+
+      - name: Debug extracted values
+        run: |
+          echo "Package name: '${{ steps.extract_pkg.outputs.name }}'"
+          echo "Package version: '${{ steps.extract_pkg.outputs.version }}'"
 
       - name: Upload Chrome extension artifact
         uses: actions/upload-artifact@v4
@@ -95,7 +72,7 @@ jobs:
           path: artifacts/firefox-mv2/*
 
   report:
-    needs: build-zips
+    needs: [build-zips]
     if: failure()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -34,17 +34,18 @@ jobs:
           echo "=== All zip files in project ==="
           find . -name "*.zip" -type f || echo "No zip files found"
 
-      - name: Get extension zip paths
-        id: zip_paths
-        run: |
-          CHROME_ZIP=$(find .output -name "*-chrome.zip" -type f | head -1)
-          FIREFOX_ZIP=$(find .output -name "*-firefox.zip" -type f | head -1)
-          echo "chrome_zip=${CHROME_ZIP}" >> "$GITHUB_OUTPUT"
-          echo "firefox_zip=${FIREFOX_ZIP}" >> "$GITHUB_OUTPUT"
-          echo "Found Chrome zip: ${CHROME_ZIP}"
-          echo "Found Firefox zip: ${FIREFOX_ZIP}"
-          echo "Debug - Chrome variable contains: '${CHROME_ZIP}'"
-          echo "Debug - Firefox variable contains: '${FIREFOX_ZIP}'"
+          - name: Get extension zip paths
+          id: zip_paths
+          run: |
+            find .output -name "*-chrome.zip" -type f | head -1 > chrome_path.txt
+            find .output -name "*-firefox.zip" -type f | head -1 > firefox_path.txt
+            CHROME_ZIP=$(cat chrome_path.txt)
+            FIREFOX_ZIP=$(cat firefox_path.txt)
+            echo "chrome_zip=${CHROME_ZIP}" >> "${GITHUB_OUTPUT}"
+            echo "firefox_zip=${FIREFOX_ZIP}" >> "${GITHUB_OUTPUT}"
+            echo "Chrome zip: ${CHROME_ZIP}"
+            echo "Firefox zip: ${FIREFOX_ZIP}"
+            rm chrome_path.txt firefox_path.txt
 
           - name: Prepare artifacts directory
           run: |

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -1,47 +1,74 @@
-name: Build and Package Extensions
+name: Build and Upload Extensions
 
 on:
   pull_request:
   workflow_dispatch:
 
 jobs:
-  package:
+  build-and-upload:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Extract package info
+        id: package_info
+        run: |
+          # Safely read package.json and sanitize name
+          NAME=$(node -p "require('./package.json').name.replace(/[@\/]/g, '-')")
+          VERSION=$(node -p "require('./package.json').version")
+
+          # Verify values exist
+          if [ -z "$NAME" ] || [ -z "$VERSION" ]; then
+            echo "::error::Could not read name/version from package.json"
+            exit 1
+          fi
+
+          echo "name=${NAME}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "chrome_zip=.output/${NAME}-${VERSION}-chrome.zip" >> $GITHUB_OUTPUT
+          echo "firefox_zip=.output/${NAME}-${VERSION}-firefox.zip" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - run: |
+      - name: Install dependencies
+        run: |
+          corepack enable
           pnpm install --frozen-lockfile
-          pnpm zip:all
 
-      - name: Extract package info
-        id: pkg
+      - name: Build extensions
+        run: pnpm zip:all
+
+      - name: Verify ZIPs exist
         run: |
-          NAME=$(node -p "require('./package.json').name.replace(/[@\/]/g, '-')")
-          VERSION=$(node -p "require('./package.json').version")
-          echo "name=${NAME}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Checking: ${{ steps.package_info.outputs.chrome_zip }}"
+          if [ ! -f "${{ steps.package_info.outputs.chrome_zip }}" ]; then
+            echo "::error::Missing Chrome ZIP"
+            ls -la .output/
+            exit 1
+          fi
 
-      - name: Verify zips exist
-        run: |
-          ls -la .output/
-          [ -f ".output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-chrome.zip" ] || exit 1
-          [ -f ".output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-firefox.zip" ] || exit 1
+          echo "Checking: ${{ steps.package_info.outputs.firefox_zip }}"
+          if [ ! -f "${{ steps.package_info.outputs.firefox_zip }}" ]; then
+            echo "::error::Missing Firefox ZIP"
+            ls -la .output/
+            exit 1
+          fi
 
-      - name: Upload Chrome (direct from .output)
+      - name: Upload Chrome extension
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-chrome-mv3'
-          path: '.output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-chrome.zip'
+          name: '${{ steps.package_info.outputs.name }}-${{ steps.package_info.outputs.version }}-chrome-mv3'
+          path: '${{ steps.package_info.outputs.chrome_zip }}'
+          retention-days: 7
 
-      - name: Upload Firefox (direct from .output)
+      - name: Upload Firefox extension
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-firefox-mv2'
-          path: '.output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-firefox.zip'
+          name: '${{ steps.package_info.outputs.name }}-${{ steps.package_info.outputs.version }}-firefox-mv2'
+          path: '${{ steps.package_info.outputs.firefox_zip }}'
+          retention-days: 7

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -24,9 +24,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Type-check (optional)
-        run: pnpm compile
-
       - name: Build and Package Extensions
         run: pnpm zip:all
 

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -7,13 +7,15 @@ on:
 jobs:
   build-zips:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          set -e
+          corepack enable
+        shell: bash
 
       - name: Setup Node.js with pnpm cache
         uses: actions/setup-node@v4
@@ -22,57 +24,76 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          set -e
+          pnpm install --frozen-lockfile
+        shell: bash
 
       - name: Build and Package Extensions
-        run: pnpm zip:all
+        run: |
+          set -e
+          pnpm zip:all
+        shell: bash
 
-      - name: Debug - List output directory
+      - name: Extract name and version from package.json
+        id: extract_pkg
+        shell: node
+        run: |
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+          if (!pkg.name || !pkg.version) {
+            console.error('package.json missing name or version');
+            process.exit(1);
+          }
+          console.log(`::set-output name=name::${pkg.name}`);
+          console.log(`::set-output name=version::${pkg.version}`);
+
+      - name: Debug - List output directory and subfolders
         run: |
           echo "=== Contents of .output directory ==="
-          ls -la .output/ || echo "No .output directory found"
-          echo "=== All zip files in project ==="
-          find . -name "*.zip" -type f || echo "No zip files found"
+          ls -la .output || (echo ".output directory not found" && exit 1)
+          echo "=== Contents of chrome-mv3 directory ==="
+          ls -la .output/chrome-mv3 || (echo "chrome-mv3 directory not found" && exit 1)
+          echo "=== Contents of firefox-mv2 directory ==="
+          ls -la .output/firefox-mv2 || (echo "firefox-mv2 directory not found" && exit 1)
+        shell: bash
 
-      - name: Get extension zip paths
-        id: zip_paths
+      - name: Prepare artifacts directory with dynamic names
         run: |
-          find .output -name "*-chrome.zip" -type f | head -1 > chrome_path.txt
-          find .output -name "*-firefox.zip" -type f | head -1 > firefox_path.txt
-          CHROME_ZIP=$(cat chrome_path.txt)
-          FIREFOX_ZIP=$(cat firefox_path.txt)
-          echo "chrome_zip=${CHROME_ZIP}" >> "${GITHUB_OUTPUT}"
-          echo "firefox_zip=${FIREFOX_ZIP}" >> "${GITHUB_OUTPUT}"
-          echo "Chrome zip: ${CHROME_ZIP}"
-          echo "Firefox zip: ${FIREFOX_ZIP}"
-          rm chrome_path.txt firefox_path.txt
-
-      - name: Prepare artifacts directory
-        run: |
+          set -e
+          ARTIFACT_BASE="${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}"
           mkdir -p artifacts
-          cp "${{ steps.zip_paths.outputs.chrome_zip }}" artifacts/
-          cp "${{ steps.zip_paths.outputs.firefox_zip }}" artifacts/
+          cp -r .output/chrome-mv3 "artifacts/${ARTIFACT_BASE}-chrome-mv3"
+          cp -r .output/firefox-mv2 "artifacts/${ARTIFACT_BASE}-firefox-mv2"
+          echo "Artifacts prepared:"
+          ls -la artifacts
+        shell: bash
 
-      - name: Upload Chrome extension artifact
+      - name: Upload chrome-mv3 artifact
         uses: actions/upload-artifact@v4
         with:
-          name: chrome-extension
-          path: artifacts/*-chrome.zip
+          name: ${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3
+          path: artifacts/${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3
 
-      - name: Upload Firefox extension artifact
+      - name: Upload firefox-mv2 artifact
         uses: actions/upload-artifact@v4
         with:
-          name: firefox-extension
-          path: artifacts/*-firefox.zip
+          name: ${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2
+          path: artifacts/${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2
 
   report:
-    needs: [build-zips]
+    needs: build-zips
     if: failure()
     runs-on: ubuntu-latest
     steps:
       - name: Report failure
         run: |
           echo "❌ Build or packaging failed."
-          echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
+          echo "GITHUB_RUN_ID=${{ github.run_id }}"
+          echo "GITHUB_WORKFLOW=${{ github.workflow }}"
+          echo "GITHUB_JOB=${{ github.job }}"
+          echo "GITHUB_REF=${{ github.ref }}"
+          echo "GITHUB_SHA=${{ github.sha }}"
+          echo "GITHUB_EVENT_NAME=${{ github.event_name }}"
+          echo "Full github context:"
+          echo "${{ toJSON(github) }}"

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -12,16 +12,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js with pnpm
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js with pnpm cache
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Enable Corepack and install pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,13 +34,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension-zip
-          path: .output/*.chrome.zip
+          path: .output/*-chrome.zip
 
       - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: firefox-extension-zip
-          path: .output/*.firefox.zip
+          path: .output/*-firefox.zip
 
   report:
     needs: [build-zips]

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -52,4 +52,6 @@ jobs:
       - name: Report failure
         run: |
           echo "❌ Build or packaging failed."
-          echo "${{ toJSON(github) }}"
+          echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -34,17 +34,27 @@ jobs:
           echo "=== All zip files in project ==="
           find . -name "*.zip" -type f || echo "No zip files found"
 
+      - name: Get extension zip paths
+        id: zip_paths
+        run: |
+          CHROME_ZIP=$(find .output -name "*-chrome.zip" -type f | head -1)
+          FIREFOX_ZIP=$(find .output -name "*-firefox.zip" -type f | head -1)
+          echo "chrome_zip=${CHROME_ZIP}" >> $GITHUB_OUTPUT
+          echo "firefox_zip=${FIREFOX_ZIP}" >> $GITHUB_OUTPUT
+          echo "Found Chrome zip: ${CHROME_ZIP}"
+          echo "Found Firefox zip: ${FIREFOX_ZIP}"
+
       - name: Upload Chrome extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension-zip
-          path: .output/deepstyled-*-chrome.zip
+          path: ${{ steps.zip_paths.outputs.chrome_zip }}
 
       - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: firefox-extension-zip
-          path: .output/deepstyled-*-firefox.zip
+          path: ${{ steps.zip_paths.outputs.firefox_zip }}
 
   report:
     needs: [build-zips]

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -50,7 +50,7 @@ jobs:
           name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome
           path: .output/chrome-mv3/
           retention-days: 30
-          compression-level: 0 # Minimal compression for faster processing
+          # compression-level: 0 # Minimal compression for faster processing
 
       - name: Create Firefox artifact (raw files)
         uses: actions/upload-artifact@v4
@@ -58,8 +58,7 @@ jobs:
           name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox
           path: .output/firefox-mv2/
           retention-days: 30
-          compression-level: 0 # Minimal compression for faster processing
-
+          # compression-level: 0 # Minimal compression for faster processing
 
       # Optional: Create release assets for tagged releases
       # - name: Create release zips

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -22,17 +22,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Setup Node.js
+      - name: Setup Node.js with pnpm cache
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
-          run_install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -27,18 +27,27 @@ jobs:
       - name: Build and Package Extensions
         run: pnpm zip:all
 
-      - name: Debug - List output directory
+      - name: Verify build outputs
         run: |
-          echo "=== Contents of .output directory ==="
-          ls -la .output/ || echo "No .output directory found"
-          echo "=== All zip files in project ==="
-          find . -name "*.zip" -type f || echo "No zip files found"
+          echo "=== Verifying build outputs ==="
+          if [ ! -d ".output/chrome-mv3" ] || [ -z "$(ls -A .output/chrome-mv3/*.zip 2>/dev/null)" ]; then
+            echo "❌ Error: No Chrome extension zip files found in .output/chrome-mv3"
+            exit 1
+          fi
+          if [ ! -d ".output/firefox-mv2" ] || [ -z "$(ls -A .output/firefox-mv2/*.zip 2>/dev/null)" ]; then
+            echo "❌ Error: No Firefox extension zip files found in .output/firefox-mv2"
+            exit 1
+          fi
+          echo "✅ Build outputs verified"
 
-      - name: Copy chrome-mv3 and firefox-mv2 to artifacts directory
+      - name: Prepare artifacts
         run: |
-          mkdir -p artifacts/chrome-mv3 artifacts/firefox-mv2
-          cp -r .output/chrome-mv3/* artifacts/chrome-mv3/ || echo "Warning: .output/chrome-mv3 missing or empty"
-          cp -r .output/firefox-mv2/* artifacts/firefox-mv2/ || echo "Warning: .output/firefox-mv2 missing or empty"
+          mkdir -p artifacts
+          # Copy with explicit zip file patterns
+          find .output/chrome-mv3 -name '*.zip' -exec cp {} artifacts/chrome-mv3.zip \;
+          find .output/firefox-mv2 -name '*.zip' -exec cp {} artifacts/firefox-mv2.zip \;
+          echo "=== Artifacts prepared ==="
+          ls -la artifacts/
 
       - name: Extract name and version from package.json
         id: extract_pkg
@@ -50,35 +59,41 @@ jobs:
             console.error('package.json missing name or version');
             process.exit(1);
           }
-          const name = pkg.name.trim();
+          const name = pkg.name.trim().replace('@', '').replace('/', '-');
           const version = pkg.version.trim();
           require('fs').appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\nversion=${version}\n`);
-
-      - name: Debug extracted values
-        run: |
-          echo "Package name: '${{ steps.extract_pkg.outputs.name }}'"
-          echo "Package version: '${{ steps.extract_pkg.outputs.version }}'"
 
       - name: Upload Chrome extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: '${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3'
-          path: artifacts/chrome-mv3/*
+          path: artifacts/chrome-mv3.zip
 
       - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: '${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2'
-          path: artifacts/firefox-mv2/*
+          path: artifacts/firefox-mv2.zip
 
   report:
     needs: [build-zips]
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Report failure
+      - name: Checkout code (for failure context)
+        uses: actions/checkout@v4
+
+      - name: Install dependencies (for failure context)
+        run: pnpm install --frozen-lockfile
+
+      - name: Detailed failure report
         run: |
-          echo "❌ Build or packaging failed."
-          echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
+          echo "❌ Build or packaging failed. Here's what we know:"
+          echo "=== Last 20 lines of build output ==="
+          tail -n 20 "$GITHUB_STEP_SUMMARY" || echo "No step summary available"
+          echo "=== Package.json contents ==="
+          cat package.json || echo "No package.json found"
+          echo "=== Build directory structure ==="
+          find .output -type f -print || echo "No .output directory found"
+          echo "=== Artifacts directory ==="
+          ls -la artifacts/ || echo "No artifacts directory found"

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -11,6 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Extract package info
         id: package_info
         run: |
@@ -36,9 +39,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: |
-          corepack enable
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Build extensions
         run: pnpm zip:all

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -38,13 +38,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension-zip
-          path: .output/*-chrome.zip
+          path: .output/deepstyled-*-chrome.zip
 
       - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
           name: firefox-extension-zip
-          path: .output/*-firefox.zip
+          path: .output/deepstyled-*-firefox.zip
 
   report:
     needs: [build-zips]

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -1,36 +1,23 @@
-name: Build and Upload Extensions
+name: Build Extension Artifacts
 
+# on:
+#   push:
+#     branches: [main, develop]
+#   pull_request:
+#     branches: [main]
+#   release:
+#     types: [published]
 on:
   pull_request:
   workflow_dispatch:
 
 jobs:
-  build-and-upload:
+  build:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Extract package info
-        id: package_info
-        run: |
-          # Safely read package.json and sanitize name
-          NAME=$(node -p "require('./package.json').name.replace(/[@\/]/g, '-')")
-          VERSION=$(node -p "require('./package.json').version")
-
-          # Verify values exist
-          if [ -z "$NAME" ] || [ -z "$VERSION" ]; then
-            echo "::error::Could not read name/version from package.json"
-            exit 1
-          fi
-
-          echo "name=${NAME}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "chrome_zip=.output/${NAME}-${VERSION}-chrome.zip" >> $GITHUB_OUTPUT
-          echo "firefox_zip=.output/${NAME}-${VERSION}-firefox.zip" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,38 +25,71 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          run_install: false
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build extensions
-        run: pnpm zip:all
-
-      - name: Verify ZIPs exist
         run: |
-          echo "Checking: ${{ steps.package_info.outputs.chrome_zip }}"
-          if [ ! -f "${{ steps.package_info.outputs.chrome_zip }}" ]; then
-            echo "::error::Missing Chrome ZIP"
-            ls -la .output/
-            exit 1
-          fi
+          pnpm build
+          pnpm build:firefox
 
-          echo "Checking: ${{ steps.package_info.outputs.firefox_zip }}"
-          if [ ! -f "${{ steps.package_info.outputs.firefox_zip }}" ]; then
-            echo "::error::Missing Firefox ZIP"
-            ls -la .output/
-            exit 1
-          fi
+      - name: Extract package info
+        id: package
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> $GITHUB_OUTPUT
+          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Upload Chrome extension
+      # These create artifacts with RAW UNCOMPRESSED files inside
+      # GitHub automatically zips the artifact for download, but contents are uncompressed
+      - name: Create Chrome artifact (raw files)
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ steps.package_info.outputs.name }}-${{ steps.package_info.outputs.version }}-chrome-mv3'
-          path: '${{ steps.package_info.outputs.chrome_zip }}'
-          retention-days: 7
+          name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome
+          path: .output/chrome-mv3/
+          retention-days: 30
+          compression-level: 0 # Minimal compression for faster processing
 
-      - name: Upload Firefox extension
+      - name: Create Firefox artifact (raw files)
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ steps.package_info.outputs.name }}-${{ steps.package_info.outputs.version }}-firefox-mv2'
-          path: '${{ steps.package_info.outputs.firefox_zip }}'
-          retention-days: 7
+          name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox
+          path: .output/firefox-mv2/
+          retention-days: 30
+          compression-level: 0 # Minimal compression for faster processing
+
+
+      # Optional: Create release assets for tagged releases
+      # - name: Create release zips
+      #   if: github.event_name == 'release'
+      #   run: |
+      #     cd .output
+      #     zip -r ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome.zip chrome-mv3/*
+      #     zip -r ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox.zip firefox-mv2/*
+
+      # - name: Upload release assets
+      #   if: github.event_name == 'release'
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ github.event.release.upload_url }}
+      #     asset_path: .output/${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome.zip
+      #     asset_name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome.zip
+      #     asset_content_type: application/zip
+
+      # - name: Upload Firefox release asset
+      #   if: github.event_name == 'release'
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ github.event.release.upload_url }}
+      #     asset_path: .output/${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox.zip
+      #     asset_name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox.zip
+      #     asset_content_type: application/zip

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -34,36 +34,36 @@ jobs:
           echo "=== All zip files in project ==="
           find . -name "*.zip" -type f || echo "No zip files found"
 
-          - name: Get extension zip paths
-          id: zip_paths
-          run: |
-            find .output -name "*-chrome.zip" -type f | head -1 > chrome_path.txt
-            find .output -name "*-firefox.zip" -type f | head -1 > firefox_path.txt
-            CHROME_ZIP=$(cat chrome_path.txt)
-            FIREFOX_ZIP=$(cat firefox_path.txt)
-            echo "chrome_zip=${CHROME_ZIP}" >> "${GITHUB_OUTPUT}"
-            echo "firefox_zip=${FIREFOX_ZIP}" >> "${GITHUB_OUTPUT}"
-            echo "Chrome zip: ${CHROME_ZIP}"
-            echo "Firefox zip: ${FIREFOX_ZIP}"
-            rm chrome_path.txt firefox_path.txt
+      - name: Get extension zip paths
+        id: zip_paths
+        run: |
+          find .output -name "*-chrome.zip" -type f | head -1 > chrome_path.txt
+          find .output -name "*-firefox.zip" -type f | head -1 > firefox_path.txt
+          CHROME_ZIP=$(cat chrome_path.txt)
+          FIREFOX_ZIP=$(cat firefox_path.txt)
+          echo "chrome_zip=${CHROME_ZIP}" >> "${GITHUB_OUTPUT}"
+          echo "firefox_zip=${FIREFOX_ZIP}" >> "${GITHUB_OUTPUT}"
+          echo "Chrome zip: ${CHROME_ZIP}"
+          echo "Firefox zip: ${FIREFOX_ZIP}"
+          rm chrome_path.txt firefox_path.txt
 
-          - name: Prepare artifacts directory
-          run: |
-            mkdir -p artifacts
-            cp "${{ steps.zip_paths.outputs.chrome_zip }}" artifacts/
-            cp "${{ steps.zip_paths.outputs.firefox_zip }}" artifacts/
+      - name: Prepare artifacts directory
+        run: |
+          mkdir -p artifacts
+          cp "${{ steps.zip_paths.outputs.chrome_zip }}" artifacts/
+          cp "${{ steps.zip_paths.outputs.firefox_zip }}" artifacts/
 
-          - name: Upload Chrome extension artifact
-            uses: actions/upload-artifact@v4
-            with:
-              name: chrome-extension
-              path: artifacts/*-chrome.zip
+      - name: Upload Chrome extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension
+          path: artifacts/*-chrome.zip
 
-          - name: Upload Firefox extension artifact
-            uses: actions/upload-artifact@v4
-            with:
-              name: firefox-extension
-              path: artifacts/*-firefox.zip
+      - name: Upload Firefox extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-extension
+          path: artifacts/*-firefox.zip
 
   report:
     needs: [build-zips]

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -85,13 +85,13 @@ jobs:
       - name: Upload Chrome extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3
+          name: '${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3'
           path: artifacts/chrome-mv3/*
 
       - name: Upload Firefox extension artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2
+          name: '${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2'
           path: artifacts/firefox-mv2/*
 
   report:

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -5,95 +5,43 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-zips:
+  package:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js with pnpm cache
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - run: |
+          pnpm install --frozen-lockfile
+          pnpm zip:all
 
-      - name: Build and Package Extensions
-        run: pnpm zip:all
-
-      - name: Verify build outputs
+      - name: Extract package info
+        id: pkg
         run: |
-          echo "=== Verifying build outputs ==="
-          if [ ! -d ".output/chrome-mv3" ] || [ -z "$(ls -A .output/chrome-mv3/*.zip 2>/dev/null)" ]; then
-            echo "❌ Error: No Chrome extension zip files found in .output/chrome-mv3"
-            exit 1
-          fi
-          if [ ! -d ".output/firefox-mv2" ] || [ -z "$(ls -A .output/firefox-mv2/*.zip 2>/dev/null)" ]; then
-            echo "❌ Error: No Firefox extension zip files found in .output/firefox-mv2"
-            exit 1
-          fi
-          echo "✅ Build outputs verified"
+          NAME=$(node -p "require('./package.json').name.replace(/[@\/]/g, '-')")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "name=${NAME}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Prepare artifacts
+      - name: Verify zips exist
         run: |
-          mkdir -p artifacts
-          # Copy with explicit zip file patterns
-          find .output/chrome-mv3 -name '*.zip' -exec cp {} artifacts/chrome-mv3.zip \;
-          find .output/firefox-mv2 -name '*.zip' -exec cp {} artifacts/firefox-mv2.zip \;
-          echo "=== Artifacts prepared ==="
-          ls -la artifacts/
+          ls -la .output/
+          [ -f ".output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-chrome.zip" ] || exit 1
+          [ -f ".output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-firefox.zip" ] || exit 1
 
-      - name: Extract name and version from package.json
-        id: extract_pkg
-        shell: node
-        run: |
-          const fs = require('fs');
-          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-          if (!pkg.name || !pkg.version) {
-            console.error('package.json missing name or version');
-            process.exit(1);
-          }
-          const name = pkg.name.trim().replace('@', '').replace('/', '-');
-          const version = pkg.version.trim();
-          require('fs').appendFileSync(process.env.GITHUB_OUTPUT, `name=${name}\nversion=${version}\n`);
-
-      - name: Upload Chrome extension artifact
+      - name: Upload Chrome (direct from .output)
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-chrome-mv3'
-          path: artifacts/chrome-mv3.zip
+          name: '${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-chrome-mv3'
+          path: '.output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-chrome.zip'
 
-      - name: Upload Firefox extension artifact
+      - name: Upload Firefox (direct from .output)
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ steps.extract_pkg.outputs.name }}-${{ steps.extract_pkg.outputs.version }}-firefox-mv2'
-          path: artifacts/firefox-mv2.zip
-
-  report:
-    needs: [build-zips]
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code (for failure context)
-        uses: actions/checkout@v4
-
-      - name: Install dependencies (for failure context)
-        run: pnpm install --frozen-lockfile
-
-      - name: Detailed failure report
-        run: |
-          echo "❌ Build or packaging failed. Here's what we know:"
-          echo "=== Last 20 lines of build output ==="
-          tail -n 20 "$GITHUB_STEP_SUMMARY" || echo "No step summary available"
-          echo "=== Package.json contents ==="
-          cat package.json || echo "No package.json found"
-          echo "=== Build directory structure ==="
-          find .output -type f -print || echo "No .output directory found"
-          echo "=== Artifacts directory ==="
-          ls -la artifacts/ || echo "No artifacts directory found"
+          name: '${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-firefox-mv2'
+          path: '.output/${{ steps.pkg.outputs.name }}-${{ steps.pkg.outputs.version }}-firefox.zip'

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -39,10 +39,12 @@ jobs:
         run: |
           CHROME_ZIP=$(find .output -name "*-chrome.zip" -type f | head -1)
           FIREFOX_ZIP=$(find .output -name "*-firefox.zip" -type f | head -1)
-          echo "chrome_zip=${CHROME_ZIP}" >> $GITHUB_OUTPUT
-          echo "firefox_zip=${FIREFOX_ZIP}" >> $GITHUB_OUTPUT
+          echo "chrome_zip=${CHROME_ZIP}" >> "$GITHUB_OUTPUT"
+          echo "firefox_zip=${FIREFOX_ZIP}" >> "$GITHUB_OUTPUT"
           echo "Found Chrome zip: ${CHROME_ZIP}"
           echo "Found Firefox zip: ${FIREFOX_ZIP}"
+          echo "Debug - Chrome variable contains: '${CHROME_ZIP}'"
+          echo "Debug - Firefox variable contains: '${FIREFOX_ZIP}'"
 
           - name: Prepare artifacts directory
           run: |

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -47,8 +47,8 @@ jobs:
           - name: Prepare artifacts directory
           run: |
             mkdir -p artifacts
-            cp ${{ steps.zip_paths.outputs.chrome_zip }} artifacts/
-            cp ${{ steps.zip_paths.outputs.firefox_zip }} artifacts/
+            cp "${{ steps.zip_paths.outputs.chrome_zip }}" artifacts/
+            cp "${{ steps.zip_paths.outputs.firefox_zip }}" artifacts/
 
           - name: Upload Chrome extension artifact
             uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -44,17 +44,23 @@ jobs:
           echo "Found Chrome zip: ${CHROME_ZIP}"
           echo "Found Firefox zip: ${FIREFOX_ZIP}"
 
-      - name: Upload Chrome extension artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: chrome-extension-zip
-          path: ${{ steps.zip_paths.outputs.chrome_zip }}
+          - name: Prepare artifacts directory
+          run: |
+            mkdir -p artifacts
+            cp ${{ steps.zip_paths.outputs.chrome_zip }} artifacts/
+            cp ${{ steps.zip_paths.outputs.firefox_zip }} artifacts/
 
-      - name: Upload Firefox extension artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: firefox-extension-zip
-          path: ${{ steps.zip_paths.outputs.firefox_zip }}
+          - name: Upload Chrome extension artifact
+            uses: actions/upload-artifact@v4
+            with:
+              name: chrome-extension
+              path: artifacts/*-chrome.zip
+
+          - name: Upload Firefox extension artifact
+            uses: actions/upload-artifact@v4
+            with:
+              name: firefox-extension
+              path: artifacts/*-firefox.zip
 
   report:
     needs: [build-zips]

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -1,46 +1,53 @@
 name: Build and Package Extensions
 
 on:
-    pull_request:
-    workflow_dispatch:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-    build-zips:
-        runs-on: ubuntu-latest
+  build-zips:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Get code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Install Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '20'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
-            - name: Install dependencies
-              run: npm ci
+      - name: Enable Corepack + Install pnpm
+        run: corepack enable && corepack prepare pnpm@latest --activate
 
-            - name: Build and Package Extensions
-              run: npm run build:all
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-            - name: Upload prod extension artifact (unzipped)
-              uses: actions/upload-artifact@v4
-              with:
-                  name: extensions-prod
-                  path: build/prod/*
+      - name: Typecheck
+        run: pnpm compile
 
-            - name: Upload release extension artifact (zipped)
-              uses: actions/upload-artifact@v4
-              with:
-                  name: extensions-releases
-                  path: build/releases/*
+      - name: Build and Package Extensions
+        run: pnpm zip:all
 
-    report:
-        needs: [build-zips]
-        if: failure()
-        runs-on: ubuntu-latest
-        steps:
-            - name: Report
-              run: |
-                  echo "Something went wrong"
-                  echo "${{ toJSON(github) }}"
+      - name: Upload Chrome extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-zip
+          path: .output/*-chrome.zip
+
+      - name: Upload Firefox extension artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-extension-zip
+          path: .output/*-firefox.zip
+
+  report:
+    needs: [build-zips]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report
+        run: |
+          echo "Something went wrong"
+          echo "${{ toJSON(github) }}"


### PR DESCRIPTION
- Switched from npm to pnpm with corepack for dependency management
- Used pnpm install with --frozen-lockfile to ensure lockfile integrity
- Replaced npm scripts with pnpm equivalents (zip:all, compile, etc.)
- Artifacts now upload only the Chrome and Firefox zip files from `.output/`
- Node.js cache set to 'pnpm' for faster installs