### PR TITLE
Update github actions workflow for artifact generation

### DIFF
--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -1,46 +1,52 @@
-name: Build and Package Extensions
+name: Build Extension Artifacts
 
 on:
-    pull_request:
-    workflow_dispatch:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-    build-zips:
-        runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Get code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Install Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '20'
+      - name: Enable Corepack
+        run: corepack enable
 
-            - name: Install dependencies
-              run: npm ci
+      - name: Setup Node.js with pnpm cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
-            - name: Build and Package Extensions
-              run: npm run build:all
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-            - name: Upload prod extension artifact (unzipped)
-              uses: actions/upload-artifact@v4
-              with:
-                  name: extensions-prod
-                  path: build/prod/*
+      - name: Build extensions
+        run: |
+          pnpm build
+          pnpm build:firefox
 
-            - name: Upload release extension artifact (zipped)
-              uses: actions/upload-artifact@v4
-              with:
-                  name: extensions-releases
-                  path: build/releases/*
+      - name: Extract package info
+        id: package
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> $GITHUB_OUTPUT
+          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-    report:
-        needs: [build-zips]
-        if: failure()
-        runs-on: ubuntu-latest
-        steps:
-            - name: Report
-              run: |
-                  echo "Something went wrong"
-                  echo "${{ toJSON(github) }}"
+      - name: Create Chrome artifact (raw files)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome
+          path: .output/chrome-mv3/
+          retention-days: 30
+          # compression-level: 0 # Minimal compression for faster processing
+
+      - name: Create Firefox artifact (raw files)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox
+          path: .output/firefox-mv2/
+          retention-days: 30
+          # compression-level: 0 # Minimal compression for faster processing

--- a/.github/workflows/pr-artifacts.yaml
+++ b/.github/workflows/pr-artifacts.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # Prevent runaway builds
 
     steps:
       - name: Checkout code
@@ -21,32 +22,115 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Verify package.json exists
+        run: |
+          if [ ! -f "package.json" ]; then
+            echo "❌ package.json not found!"
+            exit 1
+          fi
+          echo "✅ package.json found"
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          echo "📦 Installing dependencies..."
+          pnpm install --frozen-lockfile
+          echo "✅ Dependencies installed successfully"
+
+      - name: Verify WXT configuration
+        run: |
+          if [ ! -f "wxt.config.ts" ] && [ ! -f "wxt.config.js" ]; then
+            echo "⚠️ No WXT config found, using defaults"
+          else
+            echo "✅ WXT config found"
+          fi
 
       - name: Build extensions
         run: |
+          echo "🚀 Building Chrome MV3 extension..."
           pnpm build
+
+          echo "🦊 Building Firefox MV2 extension..."
           pnpm build:firefox
+
+          echo "✅ Both builds completed"
+
+      - name: Verify build outputs
+        run: |
+          echo "🔍 Checking build outputs..."
+
+          if [ ! -d ".output/chrome-mv3" ]; then
+            echo "❌ Chrome build directory not found!"
+            exit 1
+          fi
+
+          if [ ! -d ".output/firefox-mv2" ]; then
+            echo "❌ Firefox build directory not found!"
+            exit 1
+          fi
+
+          echo "📊 Build size analysis:"
+          echo "Chrome MV3: $(du -sh .output/chrome-mv3 | cut -f1)"
+          echo "Firefox MV2: $(du -sh .output/firefox-mv2 | cut -f1)"
+
+          echo "📁 Chrome build contents:"
+          ls -la .output/chrome-mv3/
+
+          echo "📁 Firefox build contents:"
+          ls -la .output/firefox-mv2/
+
+          echo "✅ Build verification complete"
 
       - name: Extract package info
         id: package
         run: |
-          echo "name=$(node -p "require('./package.json').name")" >> $GITHUB_OUTPUT
-          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+          if [ ! -f "package.json" ]; then
+            echo "❌ package.json missing for info extraction!"
+            exit 1
+          fi
 
-      - name: Create Chrome artifact (raw files)
+          NAME=$(node -p "require('./package.json').name" 2>/dev/null)
+          VERSION=$(node -p "require('./package.json').version" 2>/dev/null)
+
+          if [ -z "$NAME" ] || [ -z "$VERSION" ]; then
+            echo "❌ Failed to extract package name or version!"
+            exit 1
+          fi
+
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          echo "📦 Package: $NAME@$VERSION"
+
+      - name: Create Chrome artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome
           path: .output/chrome-mv3/
           retention-days: 30
-          # compression-level: 0 # Minimal compression for faster processing
+          compression-level: 9 # Maximum compression for smallest size
+          if-no-files-found: error # Fail if no files found
+        continue-on-error: false
 
-      - name: Create Firefox artifact (raw files)
+      - name: Create Firefox artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox
           path: .output/firefox-mv2/
           retention-days: 30
-          # compression-level: 0 # Minimal compression for faster processing
+          compression-level: 9 # Maximum compression for smallest size
+          if-no-files-found: error # Fail if no files found
+        continue-on-error: false
+
+      - name: Build summary
+        if: always() # Run even if previous steps failed
+        run: |
+          echo "🎯 Build Summary:"
+          echo "- Chrome artifact: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-chrome"
+          echo "- Firefox artifact: ${{ steps.package.outputs.name }}-${{ steps.package.outputs.version }}-firefox"
+
+          if [ -d ".output/chrome-mv3" ] && [ -d ".output/firefox-mv2" ]; then
+            echo "✅ All builds successful!"
+          else
+            echo "❌ Some builds failed!"
+            exit 1
+          fi


### PR DESCRIPTION
- Refactor the build and packaging process to generate PR artifacts optimized for browser drop-in installation (avoid zip in zip)
- Switched from `npm` to `pnpm` with `corepack` for dependency management
- Used `pnpm install with --frozen-lockfile` to ensure lockfile integrity
- Replaced npm scripts with pnpm equivalents
- Artifacts now upload only the Chrome and Firefox zip files from `.output/`
- Node.js cache set to `pnpm` for faster installs
- Add error handling and debug for build workflows