### PR TITLE
Fix roller button overlap with share button and reduce its size

### DIFF
--- a/components/ThemeManager.vue
+++ b/components/ThemeManager.vue
@@ -101,6 +101,11 @@ $blur-backdrop: blur(1rem);
 		width: var(--roller-size);
 		height: var(--roller-size);
 
+		svg {
+			width: calc(var(--roller-size) * 0.525);
+			height: calc(var(--roller-size) * 0.525);
+		}
+
 		&:hover {
 			transform: scale(1.1);
 			background-image: none;

--- a/styles/abstract/_root.scss
+++ b/styles/abstract/_root.scss
@@ -28,10 +28,11 @@
     --w-scrollbar: 0.365rem;
 
     /* ? --- DSX floating roller btn --- */
-    // --roller-top: calc(var(--h-header) + 0.5rem);
-    --roller-top: calc(var(--h-header) / 4);
-    --roller-right: var(--roller-top);
-    --roller-size: 2.8rem;
+    --roller-top: calc(var(--h-header) + 0.125rem);
+    // --roller-top: calc(var(--h-header) / 4);
+    // --roller-right: var(--roller-top);
+    --roller-right: 0.5rem;
+    --roller-size: 2.2rem;
 
     /* ? --- Border-radius --- */
     --br: 1rem;
@@ -74,7 +75,7 @@
         --p-sidebar-nav: 0.3rem;
 
         --h-header: calc(44px + 12px + 4px); // titlebar height + header pt + header pb
-        --roller-right: calc(44px + 10px + 0.2rem);
+        // --roller-right: calc(44px + 10px + 0.2rem);
         --roller-size: 2rem;
     }
 


### PR DESCRIPTION
- Fix the layout issue where the roller button overlaps the share button on certain profiles
- Decrease the size of the roller button to ensure proper spacing and alignment